### PR TITLE
fix: escape # in asset filename for rebuild workflow

### DIFF
--- a/.github/workflows/rebuild-release-assets.yml
+++ b/.github/workflows/rebuild-release-assets.yml
@@ -66,10 +66,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="${{ inputs.tag }}"
-          version="${version#v}"
           gh release upload --clobber "${{ inputs.tag }}" \
-            "target/${{ matrix.target }}/release/mfp${{ env.EXE }}#mfp-${version}-${{ matrix.artifact-name }}${{ env.EXE }}"
+            "target/${{ matrix.target }}/release/mfp${{ env.EXE }}#mfp-${{ replace(inputs.tag, 'v', '') }}-${{ matrix.artifact-name }}${{ env.EXE }}"
         shell: bash
 
   publish-crate:


### PR DESCRIPTION
The # character was being interpreted as a bash comment when using shell variable expansion, causing the Linux asset upload to fail. Now uses ${{ replace() }} expression instead of shell variables.