### PR TITLE
fix: songs cut off early when RSS duration is shorter than actual audio

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -150,11 +150,7 @@ pub fn play_audio_from_url(
         let display_position = current_position_secs
             + segment_elapsed_secs(segment_start_time, pause_started_at, total_paused_duration);
 
-        progress_bar.set_position(display_position);
-
-        if display_position >= audio_duration_sec {
-            break;
-        }
+        progress_bar.set_position(display_position.min(audio_duration_sec));
 
         if interactive {
             // Poll for key events with a short timeout (serves as the loop sleep too)


### PR DESCRIPTION
## Problem

  Songs stop playing before they finish when the RSS `itunes:duration`
  metadata is shorter than the actual MP3 audio length. The playback loop
  had a hard stop condition that fired as soon as `display_position`
  exceeded `audio_duration_sec`, killing the audio prematurely.

  ## Fix

  Remove the hard stop (`if display_position >= audio_duration_sec { break; }`).
  Playback now ends only when:
  - The decoder reaches true end-of-stream (`sink.empty()`)
  - The user presses `q`
  - The user seeks past the end

  The progress bar display is clamped to `audio_duration_sec` so it
  doesn't visually overflow past 100% on episodes where actual audio
  exceeds RSS metadata duration.

  Fixes #1